### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,29 @@
-sudo: required
-dist: trusty
 language: ruby
 
+dist: xenial
+
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libgirepository1.0-dev gir1.2-freedesktop
-  - gem update --system
+  - sudo apt-get update
+  # Provides libgirepository-1.0.so.1
+  - sudo apt-get install libgirepository-1.0-1
+  # Provides cairo-1.0.typelib
+  - sudo apt-get install gir1.2-freedesktop
+
+cache:
+  bundler: true
 
 rvm:
   - 2.4
   - 2.5
   - 2.6
-  - ruby-head
   - jruby-9.2
+  - ruby-head
   - jruby-head
 
 matrix:
   allow_failures:
-    - rvm: jruby-head
     - rvm: ruby-head
+    - rvm: jruby-head
 
 branches:
   only:

--- a/gir_ffi-cairo.gemspec
+++ b/gir_ffi-cairo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{lib,test}/**/*.rb', 'README.md', 'Rakefile', 'COPYING.LIB']
   s.test_files = Dir['test/**/*.rb']
 
-  s.add_runtime_dependency('gir_ffi', ['~> 0.15.1'])
+  s.add_runtime_dependency('gir_ffi', ['~> 0.15.2'])
   s.add_development_dependency('minitest', ['~> 5.12'])
   s.add_development_dependency('rake', ['~> 13.0'])
 


### PR DESCRIPTION
- Run on xenial distribution
- Document installed packages and install a bit less
- Cache bundle

Also:
- Bump `gir_ffi` dependency to allow running without `libgirepository1.0-dev` package