### PR TITLE
Drop support for Ruby 2.6 and JRuby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,11 +4,11 @@
 
 name: CI
 
-on:
+"on":
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   schedule:
     - cron: '16 4 12 * *'
 
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7, "3.0", "3.1", jruby-9.3]
+        ruby: [2.7, "3.0", "3.1"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
   Exclude:
     - 'examples/*'
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 # Make BeginEndAlignment behavior match EndAlignment
 Layout/BeginEndAlignment:
@@ -53,8 +53,8 @@ Lint/AssignmentInCondition:
 
 Metrics/BlockLength:
   Exclude:
-    - 'test/**/*' # Test describe blocks can be any size
-    - '*.gemspec' # Gem spec blocks can be any size
+    - 'test/**/*'  # Test describe blocks can be any size
+    - '*.gemspec'  # Gem spec blocks can be any size
 
 # Allow semantic variation in and/or external determination of symbols
 Naming/VariableNumber:

--- a/gir_ffi-cairo.gemspec
+++ b/gir_ffi-cairo.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "http://www.github.com/mvz/gir_ffi-cairo"
   spec.license = "LGPL-2.1"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/gir_ffi-cairo"


### PR DESCRIPTION
- Require Ruby 2.7
- Drop testing with CRuby 2.6 and JRuby 9.3 from GitHub Actions
- Make RuboCop target Ruby 2.7
