### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/gir_ffi-cairo.gemspec
+++ b/gir_ffi-cairo.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ["Changelog.md", "README.md"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "gir_ffi", "~> 0.17.0"
+  spec.add_dependency "gir_ffi", "~> 0.17.0"
 
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
