### PR TITLE
Update RuboCop configuration and fix new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_mode:
   merge:
     - Exclude
 
-require:
+plugins:
   - rubocop-packaging
   - rubocop-performance
   - rubocop-minitest

--- a/gir_ffi-cairo.gemspec
+++ b/gir_ffi-cairo.gemspec
@@ -32,9 +32,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.51"
+  spec.add_development_dependency "rubocop", "~> 1.76"
   spec.add_development_dependency "rubocop-minitest", "~> 0.38.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.18"
+  spec.add_development_dependency "rubocop-performance", "~> 1.25"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/test/gir_ffi-cairo/context_test.rb
+++ b/test/gir_ffi-cairo/context_test.rb
@@ -6,6 +6,7 @@ describe Cairo::Context do
   describe ".create" do
     it "creates a new Cairo::Context" do
       obj = Cairo::Context.create(nil)
+
       _(obj).must_be_instance_of Cairo::Context
     end
   end

--- a/test/gir_ffi-cairo/image_surface_test.rb
+++ b/test/gir_ffi-cairo/image_surface_test.rb
@@ -10,6 +10,7 @@ describe Cairo::ImageSurface do
   describe ".create" do
     it "creates a new Cairo::ImageSurface" do
       obj = Cairo::ImageSurface.create(:argb32, 300, 200)
+
       _(obj).must_be_instance_of Cairo::ImageSurface
     end
   end

--- a/test/gir_ffi-cairo/pdf_surface_test.rb
+++ b/test/gir_ffi-cairo/pdf_surface_test.rb
@@ -13,6 +13,7 @@ describe Cairo::PDFSurface do
 
     it "creates a new Cairo::PDFSurface" do
       obj = Cairo::PDFSurface.create(@path, 300, 200)
+
       _(obj).must_be_instance_of Cairo::PDFSurface
     end
 

--- a/test/integration/context_test.rb
+++ b/test/integration/context_test.rb
@@ -6,6 +6,7 @@ describe Cairo::Context do
   it "can retrieve the surface it was created for" do
     dst = Cairo::ImageSurface.create(:argb32, 400, 300)
     ctx = Cairo::Context.create(dst)
+
     _(ctx.get_target.to_ptr).must_equal dst.to_ptr
     pass
   end


### PR DESCRIPTION
- Bump rubocop dependencies
- Use the new rubocop plugins configuration syntax
- Autocorrect Minitest/EmptyLineBeforeAssertionMethods
